### PR TITLE
Use colours configured in the options

### DIFF
--- a/T16/GPS/main.lua
+++ b/T16/GPS/main.lua
@@ -219,8 +219,6 @@ local function update(wgt, options)
 	
 	wgt.options = options   
 
-	newtext_color = wgt.options.TextColor
-	newline_color = wgt.options.LineColor	
 end
 
 local function background(wgt)
@@ -340,6 +338,10 @@ function refresh(wgt, event, touchState)
 		print("GPS_Debug", "Widget not initialized - 2")	
 		return
 	end		
+
+	-- set the colours
+	newtext_color = wgt.options.TextColor
+	newline_color = wgt.options.LineColor	
 	
 	get_data(wgt) 	
 


### PR DESCRIPTION
The setting of the variables needs to be done as part of refresh in order ensure the colours that were configured in the options are used on widget start, rather than after the options have been updated. 

Prior to this, on widget start it was using the configured black text white lines, and then only honouring the configured colours if you entered and exited the options screen without changes. 